### PR TITLE
Fix the README usage example so it compiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ connections. You rarely need this kind of performance, but sending news letters 
 // where the connections remain open until the pool is shut down.
 SmtpConnectionPool pool = new SmtpConnectionPool(new SmtpClusterConfig());
 
-PoolableObject<Transport> poolableTransport = pool.claimResourceFromCluster(session);
+PoolableObject<SessionTransport> poolableTransport = pool.claimResourceFromCluster(session);
 // ... send the email
 poolableTransport.release(); // make available in the connection pool again
 ```


### PR DESCRIPTION
As you know the first impression is important :) That is the reason to fix the code example in the Usage section of the Readme. Actually the PoolableObject generics is SessionTransport and not Transport directly. As I have noticed it is just changed in verion 2.2.0 4 days ago. 